### PR TITLE
feat: add minimal gcp control plane

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  PROJECT_ID: ${{ secrets.PROJECT_ID }}
+  REGION: ${{ secrets.REGION }}
+  AUTH_MODE: hmac
+  BACKEND_SERVICE: backend
+  FRONTEND_SERVICE: frontend
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+    - uses: google-github-actions/setup-gcloud@v2
+      with:
+        project_id: ${{ env.PROJECT_ID }}
+    - name: Deploy
+      run: |
+        bash app/infra/deploy.sh $PROJECT_ID $REGION

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+node_modules/
+.out/
+app/frontend/out/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Google-cloud-me
+# GCP Control Plane
+
+Minimal monorepo deploying a FastAPI backend and static Next.js frontend to Cloud Run.
+
+## Quickstart
+Prereqs: gcloud CLI, project ID, region.
+
+```bash
+bash app/infra/seed_secrets.sh PROJECT_ID REGION
+bash app/infra/deploy.sh PROJECT_ID REGION AUTH_MODE=hmac
+```
+
+### Test (HMAC mode)
+```bash
+TS=$(date +%s)
+SIG=$(printf "GET\n/apis\n$TS" | openssl dgst -sha256 -hmac "<ACCESS_SECRET>" -hex | awk '{print $2}')
+curl https://BACKEND_URL/apis -H "x-ts: $TS" -H "x-sig: $SIG"
+```
+
+### Test (secure mode)
+```bash
+TOKEN=$(gcloud auth print-identity-token)
+curl https://BACKEND_URL/apis -H "Authorization: Bearer $TOKEN"
+```
+
+## Add new function
+1. Create backend route using dedicated service account and client library.
+2. Add frontend form and renderer.
+3. Update IAM roles and redeploy.

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -1,0 +1,136 @@
+import os
+import time
+import hmac
+import hashlib
+import io
+import logging
+from typing import Dict
+
+from fastapi import FastAPI, Request, HTTPException, Depends
+from fastapi.responses import JSONResponse, StreamingResponse, Response
+from fastapi.middleware.cors import CORSMiddleware
+
+from google.auth import default as google_auth_default
+from google.auth.transport.requests import AuthorizedSession
+from google.cloud import texttospeech
+from google.oauth2 import id_token
+from google.auth.transport import requests as g_requests
+
+AUTH_MODE = os.getenv("AUTH_MODE", "hmac")
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "*").split(",")
+ACCESS_SECRET = os.getenv("ACCESS_SECRET", "changeme").encode()
+LOG_PAYLOADS = os.getenv("LOG_PAYLOADS", "false").lower() == "true"
+MAX_BODY = int(os.getenv("MAX_BODY", "1000000"))
+RATE_LIMIT = int(os.getenv("RATE_LIMIT", "60"))
+
+logger = logging.getLogger("backend")
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+# simple in-memory rate limiter
+class RateLimiter:
+    def __init__(self, max_per_minute: int):
+        self.max = max_per_minute
+        self.calls: Dict[str, list] = {}
+
+    def allow(self, key: str) -> bool:
+        now = time.time()
+        bucket = self.calls.setdefault(key, [])
+        bucket = [t for t in bucket if t > now - 60]
+        self.calls[key] = bucket
+        if len(bucket) >= self.max:
+            return False
+        bucket.append(now)
+        return True
+
+limiter = RateLimiter(RATE_LIMIT)
+used_signatures = set()
+
+@app.middleware("http")
+async def check_body(request: Request, call_next):
+    body = await request.body()
+    if len(body) > MAX_BODY:
+        return Response("Payload too large", status_code=413)
+    request._body = body  # cache for later
+    return await call_next(request)
+
+@app.middleware("http")
+async def apply_rate_limit(request: Request, call_next):
+    key = f"{request.client.host}:{request.url.path}"
+    if not limiter.allow(key):
+        return Response("Too Many Requests", status_code=429)
+    return await call_next(request)
+
+async def verify_request(request: Request):
+    if AUTH_MODE == "secure":
+        auth = request.headers.get("authorization")
+        if not auth or not auth.lower().startswith("bearer "):
+            raise HTTPException(status_code=401, detail="Missing token")
+        token = auth.split()[1]
+        try:
+            decoded = id_token.verify_firebase_token(token, g_requests.Request())
+            return decoded
+        except Exception as exc:
+            raise HTTPException(status_code=401, detail="Invalid token") from exc
+    else:
+        ts = request.headers.get("x-ts")
+        sig = request.headers.get("x-sig")
+        if not ts or not sig:
+            raise HTTPException(status_code=401, detail="Missing signature")
+        if abs(int(time.time()) - int(ts)) > 120:
+            raise HTTPException(status_code=401, detail="Stale signature")
+        message = f"{request.method}\n{request.url.path}\n{ts}".encode()
+        expected = hmac.new(ACCESS_SECRET, message, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, sig) or sig in used_signatures:
+            raise HTTPException(status_code=401, detail="Bad signature")
+        used_signatures.add(sig)
+        return {}
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok"}
+
+@app.get("/apis")
+async def list_apis(_: dict = Depends(verify_request)):
+    creds, project_id = google_auth_default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    session = AuthorizedSession(creds)
+    url = f"https://serviceusage.googleapis.com/v1/projects/{project_id}/services?filter=state:ENABLED"
+    resp = session.get(url)
+    services = []
+    if resp.ok:
+        data = resp.json().get("services", [])
+        services = [s["config"]["name"] for s in data]
+    return {"services": services}
+
+@app.post("/tts/synthesize")
+async def tts_synthesize(req: Request, _: dict = Depends(verify_request)):
+    data = await req.json()
+    text = data.get("text", "")
+    voice_name = data.get("voice", "en-US-Neural2-C")
+    encoding = data.get("encoding", "MP3")
+    if len(text) > 4400:
+        raise HTTPException(status_code=413, detail="Text too long")
+    client = texttospeech.TextToSpeechClient()
+    synthesis_input = texttospeech.SynthesisInput(text=text)
+    voice = texttospeech.VoiceSelectionParams(language_code=voice_name.split("-")[0], name=voice_name)
+    audio_config = texttospeech.AudioConfig(audio_encoding=getattr(texttospeech.AudioEncoding, encoding))
+    response = client.synthesize_speech(input=synthesis_input, voice=voice, audio_config=audio_config)
+    return StreamingResponse(io.BytesIO(response.audio_content), media_type="audio/mpeg")
+
+@app.post("/client-token")
+async def client_token(data: dict):
+    path = data.get("path", "/")
+    method = data.get("method", "GET")
+    ts = str(int(time.time()))
+    message = f"{method}\n{path}\n{ts}".encode()
+    sig = hmac.new(ACCESS_SECRET, message, hashlib.sha256).hexdigest()
+    return {"ts": ts, "sig": sig}

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.114.0
+uvicorn==0.30.6
+google-cloud-texttospeech==2.16.4
+google-auth==2.33.0
+google-cloud-secret-manager==2.20.2

--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/out ./out
+RUN npm install -g serve
+CMD ["serve", "-s", "out", "-l", "8080"]

--- a/app/frontend/app/page.tsx
+++ b/app/frontend/app/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useState, useEffect } from "react";
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || "";
+
+export default function Home() {
+  const [services, setServices] = useState<string[]>([]);
+  const [text, setText] = useState("");
+  const [voice, setVoice] = useState("en-US-Neural2-C");
+  const [encoding, setEncoding] = useState("MP3");
+  const [audioUrl, setAudioUrl] = useState("");
+
+  useEffect(() => {
+    fetch(`${apiBase}/apis`).then(r => r.json()).then(d => setServices(d.services || [])).catch(() => setServices([]));
+  }, []);
+
+  const runTts = async () => {
+    let headers: any = {"Content-Type": "application/json"};
+    if (process.env.NEXT_PUBLIC_AUTH_MODE === "hmac") {
+      const ct = await fetch(`${apiBase}/client-token`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({path: "/tts/synthesize", method: "POST"})
+      }).then(r => r.json());
+      headers["x-ts"] = ct.ts;
+      headers["x-sig"] = ct.sig;
+    } else {
+      const token = await (window as any).auth?.currentUser?.getIdToken();
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+    }
+    const resp = await fetch(`${apiBase}/tts/synthesize`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({text, voice, encoding})
+    });
+    const blob = await resp.blob();
+    setAudioUrl(URL.createObjectURL(blob));
+  };
+
+  return (
+    <div style={{display: "flex", padding: 20}}>
+      <div style={{width: "30%"}}>
+        <h3>Enabled APIs</h3>
+        <ul>
+          {services.map(s => <li key={s}>{s}</li>)}
+        </ul>
+      </div>
+      <div style={{flex: 1}}>
+        <h3>Text To Speech</h3>
+        <textarea value={text} onChange={e => setText(e.target.value)} rows={4} style={{width: "100%"}} />
+        <div>
+          <label>Voice: </label>
+          <input value={voice} onChange={e => setVoice(e.target.value)} />
+        </div>
+        <div>
+          <label>Encoding: </label>
+          <input value={encoding} onChange={e => setEncoding(e.target.value)} />
+        </div>
+        <button onClick={runTts}>Run</button>
+        {audioUrl && <div><audio controls src={audioUrl}></audio><a download="tts.mp3" href={audioUrl}>Download</a></div>}
+        <h4>Add Function</h4>
+        <p>Placeholder</p>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/next-env.d.ts
+++ b/app/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/app/frontend/next.config.js
+++ b/app/frontend/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+};
+module.exports = nextConfig;

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "gcp-control-plane-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build && next export",
+    "start": "serve -s out -l 8080"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "@types/react": "18.2.21",
+    "@types/node": "20.4.1",
+    "serve": "14.2.0"
+  }
+}

--- a/app/frontend/tsconfig.json
+++ b/app/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/app/infra/deploy.sh
+++ b/app/infra/deploy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+PROJECT=$1
+REGION=$2
+AUTH_MODE=${AUTH_MODE:-hmac}
+BACKEND_SERVICE=${BACKEND_SERVICE:-backend}
+FRONTEND_SERVICE=${FRONTEND_SERVICE:-frontend}
+ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-*}
+
+# enable apis
+gcloud services enable \
+  run.googleapis.com \
+  serviceusage.googleapis.com \
+  secretmanager.googleapis.com \
+  texttospeech.googleapis.com \
+  --project $PROJECT
+
+# service accounts
+if ! gcloud iam service-accounts describe sa-core@$PROJECT.iam.gserviceaccount.com --project $PROJECT >/dev/null 2>&1; then
+  gcloud iam service-accounts create sa-core --project $PROJECT
+fi
+gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:sa-core@$PROJECT.iam.gserviceaccount.com --role roles/serviceusage.serviceUsageViewer >/dev/null
+if ! gcloud iam service-accounts describe sa-tts@$PROJECT.iam.gserviceaccount.com --project $PROJECT >/dev/null 2>&1; then
+  gcloud iam service-accounts create sa-tts --project $PROJECT
+fi
+gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:sa-tts@$PROJECT.iam.gserviceaccount.com --role roles/texttospeech.user >/dev/null
+
+# build images
+gcloud builds submit app/backend --tag gcr.io/$PROJECT/backend --project $PROJECT
+gcloud builds submit app/frontend --tag gcr.io/$PROJECT/frontend --project $PROJECT
+
+# deploy backend
+gcloud run deploy $BACKEND_SERVICE \
+  --image gcr.io/$PROJECT/backend \
+  --region $REGION \
+  --project $PROJECT \
+  --service-account sa-tts@$PROJECT.iam.gserviceaccount.com \
+  --set-env-vars AUTH_MODE=$AUTH_MODE,ALLOWED_ORIGINS=$ALLOWED_ORIGINS \
+  --set-secrets ACCESS_SECRET=ACCESS_SECRET:latest,FIREBASE_JSON=FIREBASE_JSON:latest \
+  --min-instances=1 \
+  --allow-unauthenticated
+
+backend_url=$(gcloud run services describe $BACKEND_SERVICE --region $REGION --project $PROJECT --format='value(status.url)')
+
+# deploy frontend
+gcloud run deploy $FRONTEND_SERVICE \
+  --image gcr.io/$PROJECT/frontend \
+  --region $REGION \
+  --project $PROJECT \
+  --set-env-vars NEXT_PUBLIC_API_BASE=$backend_url,NEXT_PUBLIC_AUTH_MODE=$AUTH_MODE \
+  --min-instances=1 \
+  --allow-unauthenticated

--- a/app/infra/seed_secrets.sh
+++ b/app/infra/seed_secrets.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+PROJECT=$1
+REGION=$2
+ACCESS_SECRET=$(openssl rand -hex 32)
+if gcloud secrets describe ACCESS_SECRET --project $PROJECT >/dev/null 2>&1; then
+  echo -n "$ACCESS_SECRET" | gcloud secrets versions add ACCESS_SECRET --project $PROJECT --data-file=- >/dev/null
+else
+  echo -n "$ACCESS_SECRET" | gcloud secrets create ACCESS_SECRET --project $PROJECT --data-file=- >/dev/null
+fi
+if [ -f firebase.json ]; then
+  if gcloud secrets describe FIREBASE_JSON --project $PROJECT >/dev/null 2>&1; then
+    gcloud secrets versions add FIREBASE_JSON --project $PROJECT --data-file=firebase.json >/dev/null
+  else
+    gcloud secrets create FIREBASE_JSON --project $PROJECT --data-file=firebase.json >/dev/null
+  fi
+fi
+echo "ACCESS_SECRET=$ACCESS_SECRET"


### PR DESCRIPTION
## Summary
- scaffold monorepo with FastAPI backend and Next.js frontend
- add Cloud Run deployment scripts and GitHub Actions workflow
- support HMAC or Firebase auth modes

## Testing
- `python -m py_compile app/backend/main.py`
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68aecbeb26748321bdb8659956cc9292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces an authenticated backend API with rate limiting, CORS, health check, enabled APIs listing, and Text-to-Speech output (with audio playback/download).
  - Adds a frontend UI to view enabled APIs and run Text-to-Speech.
  - Supports both HMAC and Bearer token authentication modes.

- Documentation
  - Renames and expands the README with quickstart, test flows, and guidance for adding new functions.

- Chores
  - Adds an automated deployment workflow for the main branch.
  - Provides Dockerized backend/frontend, Cloud Run deployment, and secrets seeding scripts.
  - Updates .gitignore to exclude common build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->